### PR TITLE
Eliminate N+1 Queries on departure times

### DIFF
--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,5 +1,6 @@
 class Agency < ActiveRecord::Base
   has_many :stops
+  has_many :calculated_stop_times
   has_many :trips
   has_many :stop_times
   has_many :routes

--- a/app/models/calculated_stop_time.rb
+++ b/app/models/calculated_stop_time.rb
@@ -32,12 +32,15 @@ class CalculatedStopTime < StopTime
   # on a +00 (timezone) which confuses Rails when we try to parse it to local
   # time.
   def self.select_for_departure
-    readonly.select("stop_times.id, stop_times.stop_sequence, stop_times.stop_headsign,
-           stop_times.pickup_type, stop_times.drop_off_type,
-           stop_times.shape_dist_traveled, stop_times.agency_id,
-           stop_times.stop_id, stop_times.trip_id,
-           to_char(((start_time(effective_services.date) + stop_times.arrival_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as arrival_time,
-           to_char(((start_time(effective_services.date) + stop_times.departure_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as departure_time")
+    readonly.select(<<-eos
+          stop_times.id, stop_times.stop_sequence, stop_times.stop_headsign,
+          stop_times.pickup_type, stop_times.drop_off_type,
+          stop_times.shape_dist_traveled, stop_times.agency_id,
+          stop_times.stop_id, stop_times.trip_id,
+          to_char(((start_time(effective_services.date) + stop_times.arrival_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as arrival_time,
+          to_char(((start_time(effective_services.date) + stop_times.departure_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as departure_time
+     eos
+   )
   end
 
   # Expand the service days into actual dates so that we can use them to calculate
@@ -56,7 +59,8 @@ class CalculatedStopTime < StopTime
   # (either no exception or an exception that is not 2) (exception = 2 is a
   # removed service)
   def self.joins_times(start_time, end_time)
-    joins("INNER JOIN agencies ON stop_times.agency_id = agencies.id
+    joins(<<-eos
+           INNER JOIN agencies ON stop_times.agency_id = agencies.id
            INNER JOIN trips ON stop_times.trip_id = trips.id
            INNER JOIN (
              SELECT agencies.id as agency_id, service_exceptions.service_id, d as date, rtrim(to_char(days.d, 'day')) as dow
@@ -71,7 +75,9 @@ class CalculatedStopTime < StopTime
                CROSS JOIN (SELECT d::date FROM generate_series('#{start_time.to_date}', '#{end_time.to_date}', interval '1 day') d) days
                INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id
                LEFT JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id AND service_days.id = service_exceptions.service_id
-               WHERE service_exceptions IS NULL OR service_exceptions.exception != 2) effective_services ON trips.service_id = effective_services.service_id")
+               WHERE service_exceptions IS NULL OR service_exceptions.exception != 2) effective_services ON trips.service_id = effective_services.service_id
+      eos
+    )
   end
 end
 

--- a/app/models/calculated_stop_time.rb
+++ b/app/models/calculated_stop_time.rb
@@ -1,17 +1,10 @@
 # To properly calculate actual StopTimes requires heavy lifting to be done in
 # the database. This class allows us to wrap those results and make it look
 # like a regular StopTime object
-class CalculatedStopTime < ActiveRecord::Base
-  self.table_name = :stop_times
-
-  belongs_to :stop
-  belongs_to :trip
-  belongs_to :agency
-  has_one :route, through: :trip
-  has_one :service, through: :trip
+class CalculatedStopTime < StopTime
+  self.inheritance_column = nil
 
   default_scope { select_for_departure }
-
 
   # These times are stored as intervals in the database and so they come out as
   # strings since Rails/Ruby doesn't have an interval type

--- a/app/models/calculated_stop_time.rb
+++ b/app/models/calculated_stop_time.rb
@@ -1,43 +1,84 @@
 # To properly calculate actual StopTimes requires heavy lifting to be done in
 # the database. This class allows us to wrap those results and make it look
 # like a regular StopTime object
-class CalculatedStopTime
+class CalculatedStopTime < ActiveRecord::Base
+  self.table_name = :stop_times
 
-  attr_reader :id, :stop_sequence, :stop_headsign, :arrival_time, :departure_time
-  def initialize(options)
-    @id = options[:id].to_i
-    @stop_sequence       = options[:stop_sequence].to_i
-    @stop_headsign       = options[:stop_headsign]
-    @pickup_type         = options[:pickup_type].to_i
-    @drop_off_type       = options[:drop_off_type].to_i
-    @shape_dist_traveled = options[:shape_dist_traveled].to_f
-    @agency_id           = options[:agency_id].to_i
-    @stop_id             = options[:stop_id].to_i
-    @trip_id             = options[:trip_id].to_i
-    @arrival_time        = Time.zone.parse(options[:arrival_time])   if options[:arrival_time]
-    @departure_time      = Time.zone.parse(options[:departure_time]) if options[:departure_time]
+  belongs_to :stop
+  belongs_to :trip
+  belongs_to :agency
+  has_one :route, through: :trip
+  has_one :service, through: :trip
+
+  default_scope { select_for_departure }
+
+
+  # These times are stored as intervals in the database and so they come out as
+  # strings since Rails/Ruby doesn't have an interval type
+  def arrival_time
+    Time.zone.parse(@arrival_time) if @arrival_time
   end
 
-  def agency
-    @agency ||= Agency.find_by(id: @agency_id)
+  def departure_time
+    Time.zone.parse(super) if super
   end
 
-  def stop
-    @stop ||= Stop.find_by(id: @stop_id)
+  # For departures we want to go ahead and calculate the time of the departure
+  # on the correct day. This is only going to work with the between below, or
+  # other queries that use the 'days' query
+  #
+  # HINT: If you're using this, you should be using CalculatedStopTime
+  #
+  # Timezones are hard.
+  # They need to go in/out as UTC so Rails will properly convert them to local
+  # time. But internally, we want to do comparisons in them at the timezone
+  # of the agency, so we have to conver them to the local time in the between
+  # query below.
+  #
+  # Controlling formatting of times coming out of DB because Postgres 9.3 adds
+  # on a +00 (timezone) which confuses Rails when we try to parse it to local
+  # time.
+  def self.select_for_departure
+    readonly.select("stop_times.id, stop_times.stop_sequence, stop_times.stop_headsign,
+           stop_times.pickup_type, stop_times.drop_off_type,
+           stop_times.shape_dist_traveled, stop_times.agency_id,
+           stop_times.stop_id, stop_times.trip_id,
+           to_char(((start_time(effective_services.date) + stop_times.arrival_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as arrival_time,
+           to_char(((start_time(effective_services.date) + stop_times.departure_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as departure_time")
   end
 
-  def trip
-    @trip ||= Trip.find_by(id: @trip_id)
+  # Expand the service days into actual dates so that we can use them to calculate
+  # the offset for when the bus arrives.
+  def self.between(start_time, end_time)
+    joins_times(start_time, end_time)
+      .where("(start_time(effective_services.date) + stop_times.departure_time) BETWEEN (? AT TIME ZONE agencies.timezone) AND (? AT TIME ZONE agencies.timezone)", start_time, end_time)
+      .order("start_time(effective_services.date) + stop_times.departure_time")
   end
 
-  def route
-    @route ||= trip.try(:route)
-  end
-
-  def ==(other)
-    return false unless other && (other.is_a?(StopTime) || other.is_a?(CalculatedStopTime))
-
-    other.id == self.id
+  # Effective services are those that are the the normal services for trips
+  # where service exceptions are also taken into account
+  # The first part of the union is for additions (exception = 1 is an added
+  # services)
+  # The second half of the union is for normal services that are not removed
+  # (either no exception or an exception that is not 2) (exception = 2 is a
+  # removed service)
+  def self.joins_times(start_time, end_time)
+    joins("INNER JOIN agencies ON stop_times.agency_id = agencies.id
+           INNER JOIN trips ON stop_times.trip_id = trips.id
+           INNER JOIN (
+             SELECT agencies.id as agency_id, service_exceptions.service_id, d as date, rtrim(to_char(days.d, 'day')) as dow
+             FROM agencies
+               CROSS JOIN (SELECT d::date FROM generate_series('#{start_time.to_date}', '#{end_time.to_date}', interval '1 day') d) days
+               INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id
+               INNER JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id
+               WHERE service_exceptions.exception = 1
+             UNION ALL
+             SELECT agencies.id as agency_id, service_days.id, d as date, rtrim(to_char(days.d, 'day')) as dow
+             FROM agencies
+               CROSS JOIN (SELECT d::date FROM generate_series('#{start_time.to_date}', '#{end_time.to_date}', interval '1 day') d) days
+               INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id
+               LEFT JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id AND service_days.id = service_exceptions.service_id
+               WHERE service_exceptions IS NULL OR service_exceptions.exception != 2) effective_services ON trips.service_id = effective_services.service_id")
   end
 end
 

--- a/app/models/departure_fetcher.rb
+++ b/app/models/departure_fetcher.rb
@@ -16,13 +16,10 @@ class DepartureFetcher
 
   def stop_times
     @stop_times ||= begin
-      query = agency.stop_times
+      agency.calculated_stop_times
         .where(stop: stop)
         .between(start_time, end_time)
-        .includes(:trip)
-        .select_for_departure.to_sql
-
-      ActiveRecord::Base.connection.select_all(query).map { |h| CalculatedStopTime.new(h.symbolize_keys) }
+        .preload(:stop, :trip, :route)
     end
   end
 

--- a/app/models/stop_time.rb
+++ b/app/models/stop_time.rb
@@ -1,66 +1,10 @@
+# This class is only used for CRUD on stop times
+# If you want a REAL stop time, see CalculatedStopTime
 class StopTime < ActiveRecord::Base
   belongs_to :stop
   belongs_to :trip
   belongs_to :agency
   has_one :route, through: :trip
   has_one :service, through: :trip
-
-  # For departures we want to go ahead and calculate the time of the departure
-  # on the correct day. This is only going to work with the between below, or
-  # other queries that use the 'days' query
-  #
-  # HINT: If you're using this, you should be using CalculatedStopTime
-  #
-  # Timezones are hard.
-  # They need to go in/out as UTC so Rails will properly convert them to local
-  # time. But internally, we want to do comparisons in them at the timezone
-  # of the agency, so we have to conver them to the local time in the between
-  # query below.
-  #
-  # Controlling formatting of times coming out of DB because Postgres 9.3 adds
-  # on a +00 (timezone) which confuses Rails when we try to parse it to local
-  # time.
-  def self.select_for_departure
-    readonly.select("stop_times.id, stop_times.stop_sequence, stop_times.stop_headsign,
-           stop_times.pickup_type, stop_times.drop_off_type,
-           stop_times.shape_dist_traveled, stop_times.agency_id,
-           stop_times.stop_id, stop_times.trip_id,
-           to_char(((start_time(effective_services.date) + stop_times.arrival_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as arrival_time,
-           to_char(((start_time(effective_services.date) + stop_times.departure_time) AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS') as departure_time")
-  end
-
-  # Expand the service days into actual dates so that we can use them to calculate
-  # the offset for when the bus arrives.
-  def self.between(start_time, end_time)
-    joins_times(start_time, end_time)
-      .where("(start_time(effective_services.date) + stop_times.departure_time) BETWEEN (? AT TIME ZONE agencies.timezone) AND (? AT TIME ZONE agencies.timezone)", start_time, end_time)
-      .order("start_time(effective_services.date) + stop_times.departure_time")
-  end
-
-  # Effective services are those that are the the normal services for trips
-  # where service exceptions are also taken into account
-  # The first part of the union is for additions (exception = 1 is an added
-  # services)
-  # The second half of the union is for normal services that are not removed
-  # (either no exception or an exception that is not 2) (exception = 2 is a
-  # removed service)
-  def self.joins_times(start_time, end_time)
-    joins("INNER JOIN agencies ON stop_times.agency_id = agencies.id
-           INNER JOIN trips ON stop_times.trip_id = trips.id
-           INNER JOIN (
-             SELECT agencies.id as agency_id, service_exceptions.service_id, d as date, rtrim(to_char(days.d, 'day')) as dow
-             FROM agencies
-               CROSS JOIN (SELECT d::date FROM generate_series('#{start_time.to_date}', '#{end_time.to_date}', interval '1 day') d) days
-               INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id
-               INNER JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id
-               WHERE service_exceptions.exception = 1
-             UNION ALL
-             SELECT agencies.id as agency_id, service_days.id, d as date, rtrim(to_char(days.d, 'day')) as dow
-             FROM agencies
-               CROSS JOIN (SELECT d::date FROM generate_series('#{start_time.to_date}', '#{end_time.to_date}', interval '1 day') d) days
-               INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id
-               LEFT JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id AND service_days.id = service_exceptions.service_id
-               WHERE service_exceptions IS NULL OR service_exceptions.exception != 2) effective_services ON trips.service_id = effective_services.service_id")
-  end
 end
 

--- a/spec/models/calculated_stop_time_spec.rb
+++ b/spec/models/calculated_stop_time_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe StopTime do
+RSpec.describe CalculatedStopTime do
   let(:agency) { create(:agency) }
   let(:trip) { create(:trip, agency: agency, remote_id: 940135, service: create(:service, agency: agency, tuesday: true, wednesday: true)) }
   let(:stop) { create(:stop, agency: agency, remote_id: "HAMBELi") }
   let(:ten_minutes) { Interval.new(10.minutes) }
 
-  let(:stop_times) { StopTime.between(start_time, end_time).to_a }
+  let(:stop_times) { CalculatedStopTime.between(start_time, end_time).to_a }
 
   context "stops on different days" do
     before do

--- a/spec/models/departure_fetcher_spec.rb
+++ b/spec/models/departure_fetcher_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe DepartureFetcher do
 
     it "searches stop_times within a time range and on the service" do
       expect(subject.stop_times.size).to eq(1)
+      # this is awkward, but stop times intervals are string, but current stop times convert them to dates
+      expect(subject.stop_times[0].departure_time.strftime("%H:%M:%S")).to eq(applicable_stop_time.departure_time)
     end
   end
 

--- a/spec/models/departure_fetcher_spec.rb
+++ b/spec/models/departure_fetcher_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DepartureFetcher do
     }
 
     it "searches stop_times within a time range and on the service" do
-      expect(subject.stop_times).to eq([applicable_stop_time])
+      expect(subject.stop_times.size).to eq(1)
     end
   end
 

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RealtimeDepartureFetcher do
     }
 
     it "searches stop_times within a time range and on the service" do
-      expect(subject.stop_times).to eq([applicable_stop_time])
+      expect(subject.stop_times.size).to eq(1)
     end
   end
 

--- a/spec/models/realtime_departure_fetcher_spec.rb
+++ b/spec/models/realtime_departure_fetcher_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe RealtimeDepartureFetcher do
 
     it "searches stop_times within a time range and on the service" do
       expect(subject.stop_times.size).to eq(1)
+      # this is awkward, but stop times intervals are string, but current stop times convert them to dates
+      expect(subject.stop_times[0].departure_time.strftime("%H:%M:%S")).to eq(applicable_stop_time.departure_time)
     end
   end
 


### PR DESCRIPTION
Slightly unorthodox solution, but using a default scope to choose what to select and mapping to a different table. This lets us join to the calculated stop times from the agency and use preload to force the fetching of related data using in lists of IDs.