### PR TITLE
Change controller to render index.html from S3 bucket instead of redis

### DIFF
--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -17,6 +17,11 @@ class IndexController < ApplicationController
     end
   end
 
+  def robots
+    @enable_robots = Rails.configuration.ENABLE_ROBOTS
+    render layout: false, content_type: 'text/plain'
+  end
+
   private
 
   def index_html

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,10 +1,12 @@
 class IndexController < ApplicationController
-  REDIS_KEY_PREFIX = "bus-detective:index"
-
   force_ssl if: :ssl_configured?, except: [:letsencrypt]
 
   def show
-    render text: redis.get("#{REDIS_KEY_PREFIX}:#{params[:revision] || current_index_key}")
+    if s3_bucket_url.present?
+      render text: index_html
+    else
+      render layout: false
+    end
   end
 
   def letsencrypt
@@ -17,12 +19,13 @@ class IndexController < ApplicationController
 
   private
 
-  def current_index_key
-    redis.get("#{REDIS_KEY_PREFIX}:current")
+  def index_html
+    uri = URI("#{s3_bucket_url}/index.html")
+    Net::HTTP.get(uri)
   end
 
-  def redis
-    @redis ||= Redis.new(url: ENV.fetch('REDISTOGO_URL', nil))
+  def s3_bucket_url
+    Rails.configuration.S3_BUCKET_URL
   end
 
   def ssl_configured?

--- a/app/views/index/robots.erb
+++ b/app/views/index/robots.erb
@@ -1,0 +1,6 @@
+User-agent: *
+<% if @enable_robots %>
+Allow: /
+<% else %>
+Disallow: /
+<% end %>

--- a/config/initializers/robots.rb
+++ b/config/initializers/robots.rb
@@ -1,0 +1,1 @@
+BusDetective::Application.config.ENABLE_ROBOTS = ENV['ENABLE_ROBOTS'] == 'true'

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -1,0 +1,1 @@
+BusDetective::Application.config.S3_BUCKET_URL = ENV['S3_BUCKET_URL']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
 
   get '/.well-known/acme-challenge/:id' => 'index#letsencrypt'
+  get '/robots.txt', to: 'index#robots'
   root to: "index#show"
   get "*path", to: "index#show"
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /


### PR DESCRIPTION
This gets rid of the unnecessary dependency on redis in production.

RedisToGo costs money and represents a single point of failure on a bad day. This changes the controller to proxy index.html on S3 and the ember client is set to use that location to activate deployments.